### PR TITLE
PCAの計算のタイミングの修正＋報酬関数の変更に対応＋ログの出力を追加

### DIFF
--- a/baselines/her/ddpg.py
+++ b/baselines/her/ddpg.py
@@ -11,6 +11,9 @@ from baselines.her.normalizer import Normalizer
 from baselines.her.replay_buffer import ReplayBuffer
 from baselines.common.mpi_adam import MpiAdam
 
+import sklearn
+from sklearn.decomposition import PCA
+global PCA_BUFFER # motoda
 
 def dims_to_shapes(input_dims):
     return {key: tuple([val]) if val > 0 else tuple() for key, val in input_dims.items()}
@@ -64,13 +67,15 @@ class DDPG(object):
         if self.clip_return is None:
             self.clip_return = np.inf
 
+        self.is_pca_fit = False
+        self.reward_lambda = 1.
+
         self.create_actor_critic = import_function(self.network_class)
 
         input_shapes = dims_to_shapes(self.input_dims)
         self.dimo = self.input_dims['o']
         self.dimg = self.input_dims['g']
         self.dimu = self.input_dims['u']
-
         # Prepare staging area for feeding data to the model.
         stage_shapes = OrderedDict()
         for key in sorted(self.input_dims.keys()):
@@ -262,6 +267,17 @@ class DDPG(object):
         else:
             transitions = self.buffer.sample(self.batch_size) #otherwise only sample from primary buffer
 
+
+        # --- motoda ---
+        global PCA_BUFFER
+        pos = transitions['u'][:, 0:20]
+        if self.is_pca_fit == True:
+            error = np.linalg.norm(pos - PCA_BUFFER.inverse_transform(PCA_BUFFER.transform(pos)), axis=1)
+        else:
+            error = 0.
+        transitions['r'] = transitions['r'] + self.reward_lambda * (transitions['r'] + 1.) * error
+        # --------------
+
         o, o_2, g = transitions['o'], transitions['o_2'], transitions['g']
         ag, ag_2 = transitions['ag'], transitions['ag_2']
         transitions['o'], transitions['g'] = self._preprocess_og(o, ag, g)
@@ -436,3 +452,8 @@ class DDPG(object):
         assert(len(vars) == len(state["tf"]))
         node = [tf.assign(var, val) for var, val in zip(vars, state["tf"])]
         self.sess.run(node)
+
+    def setpca(self, pca):
+        global PCA_BUFFER
+        PCA_BUFFER = pca
+        self.is_pca_fit = True

--- a/baselines/her/ddpg.py
+++ b/baselines/her/ddpg.py
@@ -275,7 +275,7 @@ class DDPG(object):
             error = np.linalg.norm(pos - PCA_BUFFER.inverse_transform(PCA_BUFFER.transform(pos)), axis=1)
         else:
             error = 0.
-        transitions['r'] = transitions['r'] + self.reward_lambda * (transitions['r'] + 1.) * error
+        transitions['r'] = transitions['r'] - self.reward_lambda * (transitions['r'] + 1.) * error
         # --------------
 
         o, o_2, g = transitions['o'], transitions['o_2'], transitions['g']

--- a/baselines/her/experiment/play.py
+++ b/baselines/her/experiment/play.py
@@ -13,7 +13,11 @@ from baselines.her.rollout import RolloutWorker
 @click.option('--seed', type=int, default=0)
 @click.option('--n_test_rollouts', type=int, default=10)
 @click.option('--render', type=int, default=1)
-def main(policy_file, seed, n_test_rollouts, render):
+@click.option('--min_num', type=int, default=100,help='minimum number of success_u whether to run PCA')
+@click.option('--num_axis', type=int, default=5,help='number of principal components to calculate the reward function')
+@click.option('--reward_lambda', type=float, default=1.,help='a weight for the second term of the reward function')
+
+def main(policy_file, seed, n_test_rollouts, render, min_num=10, num_axis=3, reward_lambda=0.7):
     set_global_seeds(seed)
 
     # Load policy.
@@ -48,7 +52,7 @@ def main(policy_file, seed, n_test_rollouts, render):
     # Run evaluation.
     evaluator.clear_history()
     for _ in range(n_test_rollouts):
-        evaluator.generate_rollouts()
+        evaluator.generate_rollouts(min_num=min_num,num_axis=num_axis,reward_lambda=reward_lambda)
 
     # record logs
     for key, val in evaluator.logs('test'):

--- a/baselines/her/experiment/success_u.py
+++ b/baselines/her/experiment/success_u.py
@@ -34,3 +34,7 @@ def calc_inverse(pos):
     global _pca
     inverse_pos = _pca.inverse_transform(pos)
     return inverse_pos
+
+def get_variance_ratio():
+    global _pca
+    return _pca.explained_variance_ratio_

--- a/baselines/her/experiment/success_u.py
+++ b/baselines/her/experiment/success_u.py
@@ -3,7 +3,16 @@ from sklearn.decomposition import PCA
 
 _success_u = []
 _lambda = 0.0
-_pca = PCA(3)
+_axis = 3 
+_pca = PCA(_axis)
+
+def set_PCA_instance():
+    global _pca, _axis
+    _pca = PCA(_axis)
+
+def set_PCA_axis(axis_c=3):
+    global _axis
+    _axis = axis_c
 
 def set_lambda(lambda_c=0.0):
     global _lambda

--- a/baselines/her/experiment/success_u.py
+++ b/baselines/her/experiment/success_u.py
@@ -1,5 +1,9 @@
+import sklearn
+from sklearn.decomposition import PCA
+
 _success_u = []
 _lambda = 0.0
+_pca = PCA(3)
 
 def set_lambda(lambda_c=0.0):
     global _lambda
@@ -16,3 +20,17 @@ def set_success_u(grasp_u = []):
 def get_success_u():
     global _success_u
     return _success_u
+
+def calc_pca():
+    global _pca
+    _pca.fit(_success_u)
+
+def calc_transform(pos):
+    global _pca
+    transformed_pos = _pca.transform(pos)
+    return transformed_pos
+
+def calc_inverse(pos):
+    global _pca
+    inverse_pos = _pca.inverse_transform(pos)
+    return inverse_pos

--- a/baselines/her/experiment/success_u.py
+++ b/baselines/her/experiment/success_u.py
@@ -1,0 +1,18 @@
+_success_u = []
+_lambda = 0.0
+
+def set_lambda(lambda_c=0.0):
+    global _lambda
+    _lambda = lambda_c
+
+def get_lambda():
+    global _lambda
+    return _lambda
+
+def set_success_u(grasp_u = []):
+    global _success_u
+    _success_u = grasp_u
+
+def get_success_u():
+    global _success_u
+    return _success_u

--- a/baselines/her/experiment/train.py
+++ b/baselines/her/experiment/train.py
@@ -93,7 +93,8 @@ def train(min_num, max_num, num_axis, reward_lambda, # nishimura
             #np.save('success_u_110.npy', success_u)
 
             su.set_success_u(success_u)
-            su.calc_pca() # PCAの計算
+            if len(success_u) > min_num:
+                su.calc_pca() # PCAの計算
 
             #clogger.info("Episode = {}".format(episode.keys()))
             # for key in episode.keys():
@@ -114,8 +115,11 @@ def train(min_num, max_num, num_axis, reward_lambda, # nishimura
         for key, val in evaluator.logs('test'):
             logger.record_tabular(key, mpi_average(val))
         if len(success_u) > min_num:
-            pca.fit(success_u)  #PCAの計算をして現時点の結果を表示する
-            for key, val in rollout_worker.logs('train', variance_ratio=pca.explained_variance_ratio_, num_axis=num_axis, grasp_pose=success_u):
+            # pca.fit(success_u)  #PCAの計算をして現時点の結果を表示する
+            su.set_success_u(success_u) # 把持姿勢をセット
+            su.calc_pca() # PCAの計算
+            variance_ratio = su.get_variance_ratio()
+            for key, val in rollout_worker.logs('train', variance_ratio=variance_ratio, num_axis=num_axis, grasp_pose=success_u):
                 logger.record_tabular(key, mpi_average(val))
         else:
             for key, val in rollout_worker.logs('train', num_axis=num_axis, grasp_pose=success_u):

--- a/baselines/her/experiment/train.py
+++ b/baselines/her/experiment/train.py
@@ -68,6 +68,7 @@ def train(min_num, max_num, num_axis, reward_lambda, # nishimura
     # motoda --
     all_success_u = [] # Dumping  grasp_pose
     policy.reward_lambda = reward_lambda 
+    pca = PCA(num_axis)
     # --
 
     logger.info("Training...")
@@ -106,8 +107,12 @@ def train(min_num, max_num, num_axis, reward_lambda, # nishimura
         logger.record_tabular('epoch', epoch)
         for key, val in evaluator.logs('test'):
             logger.record_tabular(key, mpi_average(val))
-        for key, val in rollout_worker.logs('train', variance_ratio=pca.explained_variance_ratio_, num_axis=num_axis, grasp_pose=success_u): # efit
-            logger.record_tabular(key, mpi_average(val))
+        if len(success_u) > min_num:
+            for key, val in rollout_worker.logs('train', variance_ratio=pca.explained_variance_ratio_, num_axis=num_axis, grasp_pose=success_u):
+                logger.record_tabular(key, mpi_average(val))
+        else:
+            for key, val in rollout_worker.logs('train', grasp_pose=success_u):
+                    logger.record_tabular(key, mpi_average(val))
         for key, val in policy.logs():
             logger.record_tabular(key, mpi_average(val))
 

--- a/baselines/her/experiment/train.py
+++ b/baselines/her/experiment/train.py
@@ -72,7 +72,10 @@ def train(min_num, max_num, num_axis, reward_lambda, # nishimura
     policy.reward_lambda = reward_lambda 
     pca = PCA(num_axis)
 
+    # 実装上の無理くり
     su.set_lambda(lambda_c=reward_lambda)
+    su.set_PCA_axis(axis_c=num_axis)
+    su.set_PCA_instance() # インスタンスを設定する
     # --
 
     logger.info("Training...")
@@ -115,7 +118,6 @@ def train(min_num, max_num, num_axis, reward_lambda, # nishimura
         for key, val in evaluator.logs('test'):
             logger.record_tabular(key, mpi_average(val))
         if len(success_u) > min_num:
-            # pca.fit(success_u)  #PCAの計算をして現時点の結果を表示する
             su.set_success_u(success_u) # 把持姿勢をセット
             su.calc_pca() # PCAの計算
             variance_ratio = su.get_variance_ratio()

--- a/baselines/her/experiment/train.py
+++ b/baselines/her/experiment/train.py
@@ -93,6 +93,7 @@ def train(min_num, max_num, num_axis, reward_lambda, # nishimura
             #np.save('success_u_110.npy', success_u)
 
             su.set_success_u(success_u)
+            su.calc_pca() # PCAの計算
 
             #clogger.info("Episode = {}".format(episode.keys()))
             # for key in episode.keys():

--- a/baselines/her/experiment/train.py
+++ b/baselines/her/experiment/train.py
@@ -91,8 +91,7 @@ def train(min_num, max_num, num_axis, reward_lambda, # nishimura
                 pca = PCA(num_axis)
                 pca.fit(success_u)
                 policy.setpca(pca) # pcaを渡す
-
-                print (pca.explained_variance_ratio_)
+                # print (pca.explained_variance_ratio_)
 
             # policy.store_pca_obj(pca)
             for _ in range(n_batches):
@@ -107,7 +106,7 @@ def train(min_num, max_num, num_axis, reward_lambda, # nishimura
         logger.record_tabular('epoch', epoch)
         for key, val in evaluator.logs('test'):
             logger.record_tabular(key, mpi_average(val))
-        for key, val in rollout_worker.logs('train'):
+        for key, val in rollout_worker.logs('train', variance_ratio=pca.explained_variance_ratio_, num_axis=num_axis, grasp_pose=success_u): # efit
             logger.record_tabular(key, mpi_average(val))
         for key, val in policy.logs():
             logger.record_tabular(key, mpi_average(val))

--- a/baselines/her/her.py
+++ b/baselines/her/her.py
@@ -56,20 +56,32 @@ def make_sample_her_transitions(replay_strategy, replay_k, reward_fun):
         info['u'] = transitions['u'] # motoda
 
         ### 報酬関数に含まれる誤差の計算
-        #if os.path.exists('success_u_110.npy'):
-        #    success_u = np.load('success_u_110.npy')
-        #else:
-        #    success_u = []
 
+        # ==  読み込みがうまく行かない場合の実装　by Motoda
+        # if os.path.exists('success_u_110.npy'):
+        #     success_u = np.load('success_u_110.npy')
+        # else:
+        #     success_u = []
+
+        # ==　この場面でPCAの計算を実施する場合 by Motoda
+        #success_u = su.get_success_u()
+        # if len(success_u) > 10:
+        #     pca = PCA(3) # 主成分の次元数
+        #     pca.fit(success_u)
+        #     pos = transitions['u'][:, 0:20]
+        #     info['e'] = np.linalg.norm(pos - pca.inverse_transform(pca.transform(pos)), axis=1)
+        # else:
+        #     info['e'] = [0.]*transitions['u'][:, 0:20].shape[0]
+
+        # ==　別ファイル（success_u.py）で計算を行う場合 by Motoda
         success_u = su.get_success_u()
-
         if len(success_u) > 10:
-            pca = PCA(3) # 主成分の次元数
-            pca.fit(success_u)
             pos = transitions['u'][:, 0:20]
-            info['e'] = np.linalg.norm(pos - pca.inverse_transform(pca.transform(pos)), axis=1)
+            info['e'] = np.linalg.norm(pos - su.calc_inverse(su.calc_transform(pos)), axis=1)
+            # print (info['e'])
         else:
             info['e'] = [0.]*transitions['u'][:, 0:20].shape[0]
+
 
         # Re-compute reward since we may have substituted the goal.
         reward_params = {k: transitions[k] for k in ['ag_2', 'g']} 

--- a/baselines/her/her.py
+++ b/baselines/her/her.py
@@ -1,6 +1,10 @@
 import numpy as np
 import os
 
+import sklearn
+from sklearn.decomposition import PCA
+import baselines.her.experiment.success_u as su
+
 def make_sample_her_transitions(replay_strategy, replay_k, reward_fun):
     """Creates a sample function that can be used for HER experience replay.
 
@@ -52,15 +56,15 @@ def make_sample_her_transitions(replay_strategy, replay_k, reward_fun):
         info['u'] = transitions['u'] # motoda
 
         ### 報酬関数に含まれる誤差の計算
-        import sklearn
-        from sklearn.decomposition import PCA
-        if os.path.exists('success_u.npy'):
-            success_u = np.load('success_u.npy')
-        else:
-            success_u = []
+        #if os.path.exists('success_u_110.npy'):
+        #    success_u = np.load('success_u_110.npy')
+        #else:
+        #    success_u = []
+
+        success_u = su.get_success_u()
 
         if len(success_u) > 10:
-            pca = PCA(3)
+            pca = PCA(3) # 主成分の次元数
             pca.fit(success_u)
             pos = transitions['u'][:, 0:20]
             info['e'] = np.linalg.norm(pos - pca.inverse_transform(pca.transform(pos)), axis=1)

--- a/baselines/her/her.py
+++ b/baselines/her/her.py
@@ -48,9 +48,12 @@ def make_sample_her_transitions(replay_strategy, replay_k, reward_fun):
             if key.startswith('info_'):
                 info[key.replace('info_', '')] = value
 
+        info['u'] = transitions['u'] # motoda
+
         # Re-compute reward since we may have substituted the goal.
-        reward_params = {k: transitions[k] for k in ['ag_2', 'g']}
+        reward_params = {k: transitions[k] for k in ['ag_2', 'g']} 
         reward_params['info'] = info
+
         transitions['r'] = reward_fun(**reward_params)
 
         transitions = {k: transitions[k].reshape(batch_size, *transitions[k].shape[1:])

--- a/baselines/her/her.py
+++ b/baselines/her/her.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+import os
 
 def make_sample_her_transitions(replay_strategy, replay_k, reward_fun):
     """Creates a sample function that can be used for HER experience replay.
@@ -48,7 +48,24 @@ def make_sample_her_transitions(replay_strategy, replay_k, reward_fun):
             if key.startswith('info_'):
                 info[key.replace('info_', '')] = value
 
+
         info['u'] = transitions['u'] # motoda
+
+        ### 報酬関数に含まれる誤差の計算
+        import sklearn
+        from sklearn.decomposition import PCA
+        if os.path.exists('success_u.npy'):
+            success_u = np.load('success_u.npy')
+        else:
+            success_u = []
+
+        if len(success_u) > 10:
+            pca = PCA(3)
+            pca.fit(success_u)
+            pos = transitions['u'][:, 0:20]
+            info['e'] = np.linalg.norm(pos - pca.inverse_transform(pca.transform(pos)), axis=1)
+        else:
+            info['e'] = [0.]*transitions['u'][:, 0:20].shape[0]
 
         # Re-compute reward since we may have substituted the goal.
         reward_params = {k: transitions[k] for k in ['ag_2', 'g']} 

--- a/baselines/her/rollout.py
+++ b/baselines/her/rollout.py
@@ -146,7 +146,7 @@ class RolloutWorker:
             # compute new states and observations
             for i in range(self.rollout_batch_size):
                 # -- nishimura
-                self.envs[i].set_initial_param(_reward_lambda=reward_lambda, _num_axis=num_axis)
+                # self.envs[i].set_initial_param(_reward_lambda=reward_lambda, _num_axis=num_axis)
                 # --
                 try:
                     # We fully ignore the reward here because it will have to be re-computed
@@ -155,14 +155,18 @@ class RolloutWorker:
                     if 'is_success' in info:
                         success[i] = info['is_success']
 
-                        # 継続の判定のため（ステップ数の後半10%になった時に判定を始める）
-                        if success[i] > 0 and t > self.T*0.9:
-                            dtime[i] += 1
-                        else:
-                            dtime[i] = 0
+                        # # 継続の判定のため（ステップ数の後半10%になった時に判定を始める）
+                        # if success[i] > 0 and t > self.T*0.90:
+                        #     dtime[i] += 1
+                        # else:
+                        #     dtime[i] = 0
 
-                        # 一定時間（dtime），成功判定が継続した場合，把持姿勢を追加
-                        if dtime[i] >= 5:
+                        # # 一定時間（dtime），成功判定が継続した場合，把持姿勢を追加
+                        # if dtime[i] >= 5:
+                        #     success_u.append(u[i][0:20])
+
+                        # 学習の最後5stepで成功した場合のみver
+                        if success[i] > 0 and t > self.T*0.95:
                             success_u.append(u[i][0:20])
 
                         o_new[i] = curr_o_new['observation']
@@ -249,9 +253,15 @@ class RolloutWorker:
         logs += [('episode', self.n_episodes)]
 
         # -- motoda add
-        if num_axis > 0 and variance_ratio.shape[0] > 0:
+        if num_axis > 0 and len(variance_ratio) > 0:
             for i in range(num_axis):
                 logs += [('pc_{}'.format(i+1), variance_ratio[i]*100)]
+        elif num_axis > 0 and len(variance_ratio) == 0:
+            for i in range(num_axis):
+                logs += [('pc_{}'.format(i+1), 0.0)]
+
+
+
         logs += [('num_grasp', len(grasp_pose))] 
 
         if prefix is not '' and not prefix.endswith('/'):

--- a/baselines/her/rollout.py
+++ b/baselines/her/rollout.py
@@ -156,16 +156,16 @@ class RolloutWorker:
                         success[i] = info['is_success']
 
                         ## 継続の判定のため
-                        # if success[i] > 0 and t > self.T*0.90: # ステップ数の後半10%になった時に判定を始める
-                        #     dtime[i] += 1
-                        # else:
-                        #     dtime[i] = 0
+                        #if success[i] > 0 and t > self.T*0.90: # ステップ数の後半10%になった時に判定を始める
+                        #    dtime[i] += 1
+                        #else:
+                        #    dtime[i] = 0
 
-                        # # 一定時間（dtime），成功判定が継続した場合，把持姿勢を追加
-                        # if dtime[i] >= 5:
-                        #     success_u.append(u[i][0:20])
+                        # 一定時間（dtime），成功判定が継続した場合，把持姿勢を追加
+                        #if dtime[i] >= 5:
+                        #    success_u.append(u[i][0:20])
 
-                        ## 学習の最後5stepで成功した場合のみver
+                        # 学習の最後5stepで成功した場合のみver
                         if success[i] > 0 and t > self.T*0.95:
                             success_u.append(u[i][0:20])
 
@@ -173,6 +173,8 @@ class RolloutWorker:
                     ag_new[i] = curr_o_new['achieved_goal']
                     for idx, key in enumerate(self.info_keys):
                         info_values[idx][t, i] = info[key]
+                    if self.render:
+                        self.envs[i].render()
                 except MujocoException as e:
                     return self.generate_rollouts()
 
@@ -220,8 +222,6 @@ class RolloutWorker:
         if self.compute_Q:
             self.Q_history.append(np.mean(Qs))
         self.n_episodes += self.rollout_batch_size
-
-
 
         return convert_episode_to_batch_major(episode), success_u # motoda
 

--- a/baselines/her/rollout.py
+++ b/baselines/her/rollout.py
@@ -155,19 +155,19 @@ class RolloutWorker:
                     if 'is_success' in info:
                         success[i] = info['is_success']
 
-                        # 継続の判定のため
-                        if success[i] > 0 and t > self.T*0.90: # ステップ数の後半10%になった時に判定を始める
-                            dtime[i] += 1
-                        else:
-                            dtime[i] = 0
+                        ## 継続の判定のため
+                        # if success[i] > 0 and t > self.T*0.90: # ステップ数の後半10%になった時に判定を始める
+                        #     dtime[i] += 1
+                        # else:
+                        #     dtime[i] = 0
 
-                        # 一定時間（dtime），成功判定が継続した場合，把持姿勢を追加
-                        if dtime[i] >= 5:
-                            success_u.append(u[i][0:20])
-
-                        # 学習の最後5stepで成功した場合のみver
-                        # if success[i] > 0 and t > self.T*0.95:
+                        # # 一定時間（dtime），成功判定が継続した場合，把持姿勢を追加
+                        # if dtime[i] >= 5:
                         #     success_u.append(u[i][0:20])
+
+                        ## 学習の最後5stepで成功した場合のみver
+                        if success[i] > 0 and t > self.T*0.95:
+                            success_u.append(u[i][0:20])
 
                         o_new[i] = curr_o_new['observation']
                     ag_new[i] = curr_o_new['achieved_goal']

--- a/baselines/her/rollout.py
+++ b/baselines/her/rollout.py
@@ -155,7 +155,6 @@ class RolloutWorker:
                     if 'is_success' in info:
                         success[i] = info['is_success']
 
-
                         # 継続の判定のため（ステップ数の後半10%になった時に判定を始める）
                         if success[i] > 0 and t > self.T*0.9:
                             dtime[i] += 1
@@ -165,9 +164,6 @@ class RolloutWorker:
                         # 一定時間（dtime），成功判定が継続した場合，把持姿勢を追加
                         if dtime[i] >= 5:
                             success_u.append(u[i][0:20])
-
-                        # if success[i] > 0 and t > self.T*0.9:
-                        #     success_u.append(u[i][0:20])
 
                         o_new[i] = curr_o_new['observation']
                     ag_new[i] = curr_o_new['achieved_goal']
@@ -243,7 +239,7 @@ class RolloutWorker:
         with open(path, 'wb') as f:
             pickle.dump(self.policy, f)
 
-    def logs(self, prefix='worker'):
+    def logs(self, prefix='worker', variance_ratio=[], num_axis=0, grasp_pose=[]):
         """Generates a dictionary that contains all collected statistics.
         """
         logs = []
@@ -251,6 +247,12 @@ class RolloutWorker:
         if self.compute_Q:
             logs += [('mean_Q', np.mean(self.Q_history))]
         logs += [('episode', self.n_episodes)]
+
+        # -- motoda add
+        if num_axis > 0 and variance_ratio.shape[0] > 0:
+            for i in range(num_axis):
+                logs += [('pc_{}'.format(i+1), variance_ratio[i]*100)]
+        logs += [('num_grasp', len(grasp_pose))] 
 
         if prefix is not '' and not prefix.endswith('/'):
             return [(prefix + '/' + key, val) for key, val in logs]

--- a/baselines/her/rollout.py
+++ b/baselines/her/rollout.py
@@ -155,19 +155,19 @@ class RolloutWorker:
                     if 'is_success' in info:
                         success[i] = info['is_success']
 
-                        # # 継続の判定のため（ステップ数の後半10%になった時に判定を始める）
-                        # if success[i] > 0 and t > self.T*0.90:
-                        #     dtime[i] += 1
-                        # else:
-                        #     dtime[i] = 0
+                        # 継続の判定のため
+                        if success[i] > 0 and t > self.T*0.90: # ステップ数の後半10%になった時に判定を始める
+                            dtime[i] += 1
+                        else:
+                            dtime[i] = 0
 
-                        # # 一定時間（dtime），成功判定が継続した場合，把持姿勢を追加
-                        # if dtime[i] >= 5:
-                        #     success_u.append(u[i][0:20])
+                        # 一定時間（dtime），成功判定が継続した場合，把持姿勢を追加
+                        if dtime[i] >= 5:
+                            success_u.append(u[i][0:20])
 
                         # 学習の最後5stepで成功した場合のみver
-                        if success[i] > 0 and t > self.T*0.95:
-                            success_u.append(u[i][0:20])
+                        # if success[i] > 0 and t > self.T*0.95:
+                        #     success_u.append(u[i][0:20])
 
                         o_new[i] = curr_o_new['observation']
                     ag_new[i] = curr_o_new['achieved_goal']

--- a/gym-grasp/gym_grasp/envs/hand/grasp_block.py
+++ b/gym-grasp/gym_grasp/envs/hand/grasp_block.py
@@ -7,6 +7,8 @@ from gym import utils, error
 from gym_grasp.envs import rotations, hand_env
 from gym.envs.robotics.utils import robot_get_obs
 
+import baselines.her.experiment.success_u as su # motoda
+
 try:
     import mujoco_py
 except ImportError as e:
@@ -161,9 +163,10 @@ class ManipulateEnv(hand_env.HandEnv, utils.EzPickle):
             if not 'u' in info:
                 return
 
+            c_lambda = su.get_lambda()
             success = self._is_success(achieved_goal, goal).astype(np.float32) # 成否（1,0）を取得する
             
-            reward = (success-1.) - (success*info['e'])
+            reward = (success-1.) - c_lambda * (success*info['e'])
 
             return reward
 

--- a/gym-grasp/gym_grasp/envs/hand/grasp_block.py
+++ b/gym-grasp/gym_grasp/envs/hand/grasp_block.py
@@ -308,8 +308,8 @@ class ManipulateEnv(hand_env.HandEnv, utils.EzPickle):
         achieved_goal = self._get_achieved_goal().ravel()  # this contains the object position + rotation
         # The self.object_id is an important feature
         # but does only one value in the observation array have a positive effect on RL?
-        # observation = np.concatenate([robot_qpos, robot_qvel, object_qvel, achieved_goal, [self.target_id]])
-        observation = np.concatenate([robot_qpos, robot_qvel, object_qvel, achieved_goal]) # temp
+        observation = np.concatenate([robot_qpos, robot_qvel, object_qvel, achieved_goal, [self.target_id]])
+        # observation = np.concatenate([robot_qpos, robot_qvel, object_qvel, achieved_goal]) # temp
         return {
             'observation': observation.copy(),
             'achieved_goal': achieved_goal.copy(),
@@ -354,7 +354,7 @@ class GraspBlockEnv(ManipulateEnv):
             randomize_initial_position=False, reward_type=reward_type,
             distance_threshold=0.05,
             rotation_threshold=100.0,
-            randomize_object=False, target_id = 0, num_axis = 5
+            randomize_object=True, target_id = 0, num_axis = 5
         )
 '''
 Object_list:

--- a/gym-grasp/gym_grasp/envs/hand/grasp_block.py
+++ b/gym-grasp/gym_grasp/envs/hand/grasp_block.py
@@ -99,9 +99,11 @@ class ManipulateEnv(hand_env.HandEnv, utils.EzPickle):
             relative_control=relative_control)
         utils.EzPickle.__init__(self)
 
-    def set_initial_param(self, _reward_lambda, _num_axis):
+    def set_initial_param(self, _reward_lambda, _num_axis, _target_id, _randomize_object):
         self.reward_lambda = _reward_lambda # a weight for the second term of the reward function (float)
         self.num_axis = _num_axis # the number of components
+        self.target_id = _target_id
+        self.randomize_object = _randomize_object
 
     def _get_achieved_goal(self):
         # Object position and rotation.
@@ -160,7 +162,9 @@ class ManipulateEnv(hand_env.HandEnv, utils.EzPickle):
                 return
 
             success = self._is_success(achieved_goal, goal).astype(np.float32) # 成否（1,0）を取得する
-            reward = (success-1.)
+            
+            reward = (success-1.) - (success*info['e'])
+
             return reward
 
     # RobotEnv methods
@@ -354,7 +358,7 @@ class GraspBlockEnv(ManipulateEnv):
             randomize_initial_position=False, reward_type=reward_type,
             distance_threshold=0.05,
             rotation_threshold=100.0,
-            randomize_object=True, target_id = 0, num_axis = 5
+            randomize_object=False, target_id = 0, num_axis = 5
         )
 '''
 Object_list:

--- a/visualize/see_pca_axis.py
+++ b/visualize/see_pca_axis.py
@@ -16,7 +16,27 @@ args = parser.parse_args()
 model = load_model_from_path(args.dir + "/gym-grasp/gym_grasp/envs/assets/hand/hand.xml")
 sim = MjSim(model)
 
-dataset_path = args.dir + "/policy/{}/{}".format("210215", "grasp_dataset_30.npy")
+# motoda ---------------------------------------
+
+#file_npy = "total_grasp_dataset.npy"
+file_npy = "grasp_dataset_30.npy"
+folder_name = "Last5_Off_Init_grasp/070/3"
+
+## Axis 3
+#folder_name = "axis_3/Last5_Off_Init_grasp"
+#folder_name = "axis_3/Last5_On_Init_grasp"
+#folder_name = "axis_3/Sequence5_Off_Init_grasp"
+#folder_name = "axis_3/Sequence5_On_Init_grasp"
+
+## Axis 5
+#folder_name = "axis_5/Last5_Off_Init_grasp"
+#folder_name = "axis_5/Last5_Off_On_grasp"
+#folder_name = "axis_5/Sequence5_Off_Init_grasp"
+#folder_name = "axis_5/Sequence5_On_Init_grasp"
+
+# ----------------------------------------------
+dataset_path = args.dir + "/policy/{}/{}".format(folder_name, file_npy)
+# dataset_path = args.dir + "/policy/{}/{}".format("210215", "grasp_dataset_30.npy")
 
 viewer = MjViewer(sim)
 


### PR DESCRIPTION
ロボメカに投稿された論文への対応

- PCAの計算のタイミングを変更（1 episodeに一回）
- 報酬関数を修正（see the paper）
- 成功把持姿勢を90-100 steps の間で5step継続して把持に成功した場合のみ追加．
- 学習実行時のオプションの追加（--is_init_grasp : bool, 初期把持姿勢の有無, default=True）
- 学習実行時のオプションの追加（--logdir_init : str, 事前学習データを利用する場合のパス指定, default=None）
- logに把持姿勢（train/num_grasp）と最新の主成分寄与率を表示（train/pc_1, ~/pc_2, ~/pc_3, ...)

学習1epochあたりおよそ１分で計算できます（把持姿勢数により前後）
ただし，成功把持姿勢の追加条件が厳しくなったので，あまり姿勢が増えず，寄与率が上がりにくい．